### PR TITLE
Fix deep highlighting clicks while node is selected

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
 var boxFocused = undefined;
-let currentBox = null;
 var colourArray = ['#ffffff', '#8888ff', '#88ff88', '#ff8888', 'ffff88'];
 
 
@@ -93,14 +92,14 @@ function setup()
 		}
 	}
 	document.getElementsByTagName("body")[0].addEventListener("click", bgClick);
-	document.getElementById("doDeepUsage").addEventListener("click", () => forceBoxRehighlight(currentBox))
+	document.getElementById("doDeepUsage").addEventListener("click", () => forceBoxRehighlight(boxFocused))
 	drawArrows();
 }
 
-function forceBoxRehighlight(currentBox)
+function forceBoxRehighlight(boxFocused)
 {
-	if (boxFocused && currentBox) {
-		highlight(currentBox);
+	if (boxFocused) {
+		highlight(boxFocused);
 	}
 }
 function drawArrows()
@@ -154,7 +153,7 @@ function boxHover(event)
 	if(!boxFocused)
 	{
 		highlight(event.target);
-		currentBox = event.target;
+		boxFocused = event.target;
 	}
 }
 function highlight(box)
@@ -277,7 +276,7 @@ function boxClick(event)
 	{
 		box = box.parentElement;
 	}
-	boxFocused = box.id;
+	boxFocused = box;
 	highlight(box);
 }
 

--- a/script.js
+++ b/script.js
@@ -97,12 +97,12 @@ function setup()
 	drawArrows();
 }
 
-function forceBoxRehighlight(currentBox) {
+function forceBoxRehighlight(currentBox)
+{
 	if (boxFocused && currentBox) {
-		highlight(currentBox)
+		highlight(currentBox);
 	}
 }
-
 function drawArrows()
 {
 	//form arrow

--- a/script.js
+++ b/script.js
@@ -152,7 +152,6 @@ function boxHover(event)
 	if(!boxFocused)
 	{
 		highlight(event.target);
-		boxFocused = event.target;
 	}
 }
 function highlight(box)

--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 var boxFocused = undefined;
+let currentBox = null;
 var colourArray = ['#ffffff', '#8888ff', '#88ff88', '#ff8888', 'ffff88'];
+
 
 function setup()
 {
@@ -91,7 +93,14 @@ function setup()
 		}
 	}
 	document.getElementsByTagName("body")[0].addEventListener("click", bgClick);
+	document.getElementById("doDeepUsage").addEventListener("click", () => forceBoxRehighlight(currentBox))
 	drawArrows();
+}
+
+function forceBoxRehighlight(currentBox) {
+	if (boxFocused && currentBox) {
+		highlight(currentBox)
+	}
 }
 
 function drawArrows()
@@ -145,6 +154,7 @@ function boxHover(event)
 	if(!boxFocused)
 	{
 		highlight(event.target);
+		currentBox = event.target;
 	}
 }
 function highlight(box)

--- a/script.js
+++ b/script.js
@@ -1,7 +1,6 @@
 var boxFocused = undefined;
 var colourArray = ['#ffffff', '#8888ff', '#88ff88', '#ff8888', 'ffff88'];
 
-
 function setup()
 {
 	//Check if any checkboxes were checked in previous loads of thsi page


### PR DESCRIPTION
Fix #4 

This adds in a force rehighlighting function which triggers when clicking the doDeepUsage input element. It does this by keeping track of the currently selected box and utilising that when clicking the input

I would use boxFocused. however as the current listeners make this undefined when clicking off of the box via bgClick I thought it easier to just keep track of it this way